### PR TITLE
sorting glob files for text-dependent ref

### DIFF
--- a/synthesize.py
+++ b/synthesize.py
@@ -44,7 +44,7 @@ def synthesize():
 
     # reference audio
     mels, maxlen = [], 0
-    files = glob(hp.ref_audio)
+    files = sorted(glob(hp.ref_audio))
     for f in files:
         _, mel, _ = load_spectrograms(f)
         mel = np.reshape(mel, (-1, hp.n_mels))


### PR DESCRIPTION
The prosody is not clear for independent reference audio.
It should be sorted to use text-dependent reference audio.
It seems that you have omitted this partial code when experimenting with independent ref.